### PR TITLE
Added predefined CRS

### DIFF
--- a/BlazorLeaflet/BlazorLeaflet/LeafletInterops.cs
+++ b/BlazorLeaflet/BlazorLeaflet/LeafletInterops.cs
@@ -9,14 +9,18 @@ namespace BlazorLeaflet
 {
     public static class LeafletInterops
     {
-
         private static readonly string _BaseObjectContainer = "window.leafletBlazor";
 
-        public static ValueTask Create(IJSRuntime jsRuntime, string mapId, System.Drawing.PointF initCenterPosition, float initialZoom)
+        public static ValueTask Create(IJSRuntime jsRuntime, string mapId, MapArgs args)
         {
-            return jsRuntime.InvokeVoidAsync($"{_BaseObjectContainer}.create", mapId, initCenterPosition, initialZoom);
+            return jsRuntime.InvokeVoidAsync($"{_BaseObjectContainer}.create", mapId, args, DotNetObjectReference.Create(args));
         }
 
+        public static ValueTask<bool> IsLoaded(IJSRuntime jsRuntime, string mapId)
+        {
+            return jsRuntime.InvokeAsync<bool>($"{_BaseObjectContainer}.isLoaded", mapId);
+        }
+        
         public static ValueTask AddLayer(IJSRuntime jsRuntime, string mapId, Layer layer) =>
             layer switch
             {
@@ -44,6 +48,10 @@ namespace BlazorLeaflet
         {
             return jsRuntime.InvokeVoidAsync($"{_BaseObjectContainer}.panTo", mapId, position, animate, duration, easeLinearity, noMoveStart);
         }
-
+        
+        public static ValueTask SetMaxBounds(IJSRuntime jsRuntime, string mapId, PointF corner1, PointF corner2)
+        {
+            return jsRuntime.InvokeVoidAsync($"{_BaseObjectContainer}.setMaxBounds", mapId, corner1, corner2);
+        }
     }
 }

--- a/BlazorLeaflet/BlazorLeaflet/LeafletMap.razor
+++ b/BlazorLeaflet/BlazorLeaflet/LeafletMap.razor
@@ -9,14 +9,24 @@
 
     [Parameter] public Map Map { get; set; }
     [Parameter] public PointF InitialPosition { get; set; } = PointF.Empty;
-    [Parameter] public float InitialZoom { get; set; } = 13f;
-
+    [Parameter] public float? InitialZoom { get; set; } = 13f;
+    [Parameter] public float? MaxZoom { get; set; }
+    [Parameter] public float? MinZoom { get; set; }
+    [Parameter] public PredefinedCRS CRS { get; set; }
 
     protected override async Task OnAfterRenderAsync(bool firstRender)
     {
         if (firstRender)
         {
-            await LeafletInterops.Create(JsRuntime, Map.Id, InitialPosition, InitialZoom);
+            var args = new MapArgs
+            {
+                Center = InitialPosition,
+                Zoom = InitialZoom,
+                MaxZoom = MaxZoom,
+                MinZoom = MinZoom,
+                CRS = CRS.ToString()
+            };
+            await LeafletInterops.Create(JsRuntime, Map.Id, args);
 
             Map.Layers.CollectionChanged += OnLayersChanged;
             foreach (var layer in Map.Layers.ToList())

--- a/BlazorLeaflet/BlazorLeaflet/Map.cs
+++ b/BlazorLeaflet/BlazorLeaflet/Map.cs
@@ -3,14 +3,15 @@ using BlazorLeaflet.Models;
 using BlazorLeaflet.Utils;
 using System.Collections.ObjectModel;
 using System.Drawing;
+using System.Threading.Tasks;
 using Microsoft.JSInterop;
 
 namespace BlazorLeaflet
 {
     public class Map
     {
-
         public string Id { get; }
+        
         public ObservableCollection<Layer> Layers { get; set; } = new ObservableCollection<Layer>();
 
         private readonly IJSRuntime _jsRuntime;
@@ -20,16 +21,25 @@ namespace BlazorLeaflet
             _jsRuntime = jsRuntime ?? throw new ArgumentNullException(nameof(jsRuntime));
             Id = StringHelper.GetRandomString(10);
         }
-
-        public void FitBounds(PointF corner1, PointF corner2, PointF? padding = null, float? maxZoom = null)
+        
+        public ValueTask<bool> IsLoaded()
         {
-            LeafletInterops.FitBounds(_jsRuntime, Id, corner1, corner2, padding, maxZoom);
+            return LeafletInterops.IsLoaded(_jsRuntime, Id);
+        }
+
+        public ValueTask FitBounds(PointF corner1, PointF corner2, PointF? padding = null, float? maxZoom = null)
+        {
+            return LeafletInterops.FitBounds(_jsRuntime, Id, corner1, corner2, padding, maxZoom);
         }
         
-        public void PanTo(PointF position, bool animate = false, float duration = 0.25f, float easeLinearity = 0.25f, bool noMoveStart = false)
+        public ValueTask PanTo(PointF position, bool animate = false, float duration = 0.25f, float easeLinearity = 0.25f, bool noMoveStart = false)
         {
-            LeafletInterops.PanTo(_jsRuntime, Id, position, animate, duration, easeLinearity, noMoveStart);
+            return LeafletInterops.PanTo(_jsRuntime, Id, position, animate, duration, easeLinearity, noMoveStart);
         }
 
+        public ValueTask SetMaxBounds(PointF corner1, PointF corner2)
+        {
+            return LeafletInterops.SetMaxBounds(_jsRuntime, Id, corner1, corner2);
+        }
     }
 }

--- a/BlazorLeaflet/BlazorLeaflet/Models/GridLayer.cs
+++ b/BlazorLeaflet/BlazorLeaflet/Models/GridLayer.cs
@@ -26,6 +26,16 @@ namespace BlazorLeaflet.Models
         public int ZIndex { get; set; } = 1;
 
         /// <summary>
+        /// Minimum zoom number the tile source has available. If it is specified, the tiles on all zoom levels lower than minNativeZoom will be loaded from minNativeZoom level and auto-scaled.
+        /// </summary>
+        public double? MinNativeZoom { get; set; }
+
+        /// <summary>
+        ///  Maximum zoom number the tile source has available. If it is specified, the tiles on all zoom levels higher than maxNativeZoom will be loaded from maxNativeZoom level and auto-scaled.
+        /// </summary>
+        public double? MaxNativeZoom { get; set; }
+
+        /// <summary>
         /// If set, tiles will only be loaded inside the set.
         /// </summary>
         public Tuple<double, double> Bounds { get; set; }

--- a/BlazorLeaflet/BlazorLeaflet/Models/MapArgs.cs
+++ b/BlazorLeaflet/BlazorLeaflet/Models/MapArgs.cs
@@ -1,0 +1,32 @@
+using System.Drawing;
+
+namespace BlazorLeaflet.Models
+{
+    public class MapArgs
+    {
+        /// <summary>
+        /// Coordinate Reference System to use. Don't change this if you're not sure what it means. By default it is EPSG3857
+        /// </summary>
+        public string CRS { get; set; }
+        
+        /// <summary>
+        /// Initial geographical center of the map.
+        /// </summary>
+        public PointF Center { get; set; }
+        
+        /// <summary>
+        /// Initial map zoom.
+        /// </summary>
+        public float? Zoom { get; set; }
+        
+        /// <summary>
+        /// Minimum zoom level of the map. Overrides any minZoom set on map layers.
+        /// </summary>
+        public float? MinZoom { get; set; }
+        
+        /// <summary>
+        /// Maximum zoom level of the map. This overrides any maxZoom set on map layers.
+        /// </summary>
+        public float? MaxZoom { get; set; }
+    }
+}

--- a/BlazorLeaflet/BlazorLeaflet/Models/PredefinedCRS.cs
+++ b/BlazorLeaflet/BlazorLeaflet/Models/PredefinedCRS.cs
@@ -1,0 +1,26 @@
+namespace BlazorLeaflet.Models
+{
+    public enum PredefinedCRS
+    {
+        /// <summary>
+        /// The most common CRS for online maps, used by almost all free and commercial tile providers. Uses Spherical Mercator projection. Set in by default in Map's crs option.
+        /// </summary>
+        EPSG3857,
+        /// <summary>
+        /// A common CRS among GIS enthusiasts. Uses simple Equirectangular projection.
+        /// </summary>
+        EPSG4326,
+        /// <summary>
+        /// Rarely used by some commercial tile providers. Uses Elliptical Mercator projection.
+        /// </summary>
+        EPSG3395,
+        /// <summary>
+        /// A simple CRS that maps longitude and latitude into x and y directly. May be used for maps of flat surfaces (e.g. game maps). Note that the y axis should still be inverted (going from bottom to top).
+        /// </summary>
+        Simple,
+        /// <summary>
+        /// A simple CRS that maps longitude and latitude into x and y directly. May be used for maps of flat surfaces (e.g. game maps). X and Y reverted, i.e. Simple is (y, x), SimpleXY is (x,y)
+        /// </summary>
+        SimpleXY
+    }
+}


### PR DESCRIPTION
My apologies for including multiple changes in one PR

- Added partial support for CRS (coordinate systems). At the moment added support only for predefined systems plus one that is very useful for 2D maps (SimplyXY)
- Added IsLoaded method which allows to check whether the map is loaded or not, useful when maps are dynamically loaded/unloaded
- Added MinZoom/MaxZoom args to Map
- Added SetMaxBounds method to Map
- Added MinNativeZoom/MaxNativeZoom to GridLayer
- Wrapped L.map args to a separate