### PR TITLE
Fix TileSize property

### DIFF
--- a/BlazorLeaflet/BlazorLeaflet/Models/GridLayer.cs
+++ b/BlazorLeaflet/BlazorLeaflet/Models/GridLayer.cs
@@ -9,7 +9,7 @@ namespace BlazorLeaflet.Models
         /// <summary>
         /// Width and height of tiles in the grid.
         /// </summary>
-        public Size Size { get; set; } = new Size(256, 256);
+        public Size TileSize { get; set; } = new Size(256, 256);
 
         public double Opacity { get; set; } = 1.0;
 

--- a/BlazorLeaflet/BlazorLeaflet/wwwroot/leafletBlazorInterops.js
+++ b/BlazorLeaflet/BlazorLeaflet/wwwroot/leafletBlazorInterops.js
@@ -20,7 +20,7 @@ window.leafletBlazor = {
             attribution: tileLayer.attribution,
             pane: tileLayer.pane,
             // ---
-            size: tileLayer.size ? L.point(tileLayer.size.width, tileLayer.size.height) : undefined,
+            tileSize: tileLayer.tileSize ? L.point(tileLayer.tileSize.width, tileLayer.tileSize.height) : undefined,
             opacity: tileLayer.opacity,
             updateWhenZooming: tileLayer.updateWhenZooming,
             updateInterval: tileLayer.updateInterval,


### PR DESCRIPTION
`GridLayer.Size` is incorrectly named and maps to a non-existent JS property (actual property is [`tileSize`](https://leafletjs.com/reference-1.6.0.html#gridlayer-tilesize)).