### PR TITLE
#32 Allow Center and Zoom to be set after initialization

### DIFF
--- a/BlazorLeaflet/BlazorLeaflet.Samples/Pages/Index.razor
+++ b/BlazorLeaflet/BlazorLeaflet.Samples/Pages/Index.razor
@@ -1,4 +1,4 @@
-﻿@page "/"
+@page "/"
 @using System.Drawing
 @using BlazorLeaflet.Models
 @inject CityService cityService
@@ -14,6 +14,7 @@
     <button class="btn btn-primary mb-2" @onclick="FindCity">Search</button>
     <button class="btn btn-primary mb-2" @onclick="ZoomMap">Zoom</button>
     <button class="btn btn-primary mb-2" @onclick="PanToNY">Pan to New York</button>
+    <button class="btn btn-primary mb-2" @onclick="SetToNY">Set center at New York</button>
 </div>
 
 <div style="height: 500px; width: 500px;">
@@ -108,6 +109,12 @@
     private void PanToNY()
     {
         _map.PanTo(new PointF(40.713185f, -74.0072333f), animate: true, duration: 10f);
+    }
+
+    private void SetToNY()
+    {
+        _map.Center = new LatLng(new PointF(40.713185f, -74.0072333f));
+        _map.Zoom = 15;
     }
 
 }

--- a/BlazorLeaflet/BlazorLeaflet/LeafletInterops.cs
+++ b/BlazorLeaflet/BlazorLeaflet/LeafletInterops.cs
@@ -88,6 +88,11 @@ namespace BlazorLeaflet
         public static ValueTask<float> GetZoom(IJSRuntime jsRuntime, string mapId) =>
             jsRuntime.InvokeAsync<float>($"{_BaseObjectContainer}.getZoom", mapId);
 
+        public static async Task SetZoom(IJSRuntime jsRuntime, string mapId, float zoomLevel)
+        {
+            await jsRuntime.InvokeVoidAsync($"{_BaseObjectContainer}.setZoom", mapId, zoomLevel);
+        }
+
         public static ValueTask ZoomIn(IJSRuntime jsRuntime, string mapId, MouseEventArgs e) =>
             jsRuntime.InvokeVoidAsync($"{_BaseObjectContainer}.zoomIn", mapId, e);
 

--- a/BlazorLeaflet/BlazorLeaflet/Models/Bounds.cs
+++ b/BlazorLeaflet/BlazorLeaflet/Models/Bounds.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace BlazorLeaflet.Models
+{
+    public class Bounds
+    {
+        [DataMember(Name = "_northEast")]
+        public LatLng NorthEast { get; set; }
+
+        [DataMember(Name = "_southWest")]
+        public LatLng SouthWest { get; set; }
+
+        public Bounds() { }
+        public Bounds(LatLng southWest, LatLng northEast)
+        {
+            NorthEast = northEast;
+            SouthWest = southWest;
+        }
+
+        public override string ToString() =>
+            $"NE: {NorthEast.Lat} N, {NorthEast.Lng} E; SW: {SouthWest.Lat} N, {SouthWest.Lng} E";
+    }
+}

--- a/BlazorLeaflet/BlazorLeaflet/wwwroot/leafletBlazorInterops.js
+++ b/BlazorLeaflet/BlazorLeaflet/wwwroot/leafletBlazorInterops.js
@@ -1,4 +1,4 @@
-﻿maps = {};
+maps = {};
 layers = {};
 
 window.leafletBlazor = {
@@ -221,6 +221,12 @@ window.leafletBlazor = {
         if (map.getZoom() > map.getMinZoom()) {
             map.zoomOut(map.options.zoomDelta * (e.shiftKey ? 3 : 1));
         }
+    },
+    getBounds: function (mapId) {
+        return maps[mapId].getBounds();
+    },
+    setZoom: function (mapId, zoomLevel) {
+        maps[mapId].setZoom(zoomLevel);
     }
 };
 


### PR DESCRIPTION
Currently, Center and Zoom only take effect at initialization. This pull request allows Center and Zoom to be set after initialization, and it will apply these changes to the map automatically. There is an optional error handler property that allows you to specify an action that gets run if an error occurs in an async method.