### PR TITLE
Likely workaround #41 icon size/anchor in WASM

### DIFF
--- a/BlazorLeaflet/BlazorLeaflet/Models/Icon.cs
+++ b/BlazorLeaflet/BlazorLeaflet/Models/Icon.cs
@@ -15,15 +15,25 @@ namespace BlazorLeaflet.Models
         /// </summary>
         public string RetinalUrl { get; set; }
 
-        /// <summary>
-        /// Size of the icon image in pixels.
-        /// </summary>
-        public Size? Size { get; set; }
+        public bool HasSize { get; set; }
 
         /// <summary>
-        /// The coordinates of the "tip" of the icon (relative to its top left corner). The icon will be aligned so that this point is at the marker's geographical location. Centered by default if size is specified, also can be set in CSS with negative margins.
+        /// <para>Size of the icon image in pixels.</para>
+        /// 
+        /// <para>To use, set <see cref="HasSize"/> to <see cref="true"/>.</para>
         /// </summary>
-        public Point? Anchor { get; set; }
+        public Size Size { get; set; }
+
+        public bool HasAnchor { get; set; }
+
+        /// <summary>
+        /// <para>The coordinates of the "tip" of the icon (relative to its top left corner). The icon will be aligned
+        /// so that this point is at the marker's geographical location. Centered by default if size is specified, also
+        /// can be set in CSS with negative margins.</para>
+        /// 
+        /// <para>To use, set <see cref="HasAnchor"/> to <see cref="true"/>.</para>
+        /// </summary>
+        public Point Anchor { get; set; }
 
         /// <summary>
         /// The coordinates of the point from which popups will "open", relative to the icon anchor.

--- a/BlazorLeaflet/BlazorLeaflet/wwwroot/leafletBlazorInterops.js
+++ b/BlazorLeaflet/BlazorLeaflet/wwwroot/leafletBlazorInterops.js
@@ -228,8 +228,8 @@ function createIcon(icon) {
     return L.icon({
         iconUrl: icon.url,
         iconRetinaUrl: icon.retinaUrl,
-        iconSize: icon.size ? L.point(icon.size.value.width, icon.size.value.height) : null,
-        iconAnchor: icon.anchor ? L.point(icon.anchor.value.x, icon.anchor.value.y) : null,
+        iconSize: icon.hasSize ? L.point(icon.size.width, icon.size.height) : null,
+        iconAnchor: icon.hasAnchor ? L.point(icon.anchor.x, icon.anchor.y) : null,
         popupAnchor: L.point(icon.popupAnchor.x, icon.popupAnchor.y),
         tooltipAnchor: L.point(icon.tooltipAnchor.x, icon.tooltipAnchor.y),
         shadowUrl: icon.shadowUrl,


### PR DESCRIPTION
(Drafting this while I test it locally.)

Once https://github.com/dotnet/runtime/issues/39208 is fixed, this can be reverted.